### PR TITLE
publish also the source folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-test-runner",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
     "name": "@oat-sa/tao-test-runner",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "displayName": "TAO Test Runner",
     "description": "TAO Test Runner API",
     "files": [
-        "dist"
+        "dist",
+        "src"
     ],
     "scripts": {
         "test": "npx qunit-testrunner",


### PR DESCRIPTION
In order to use the sources from an app, in ES2015 format, we need to expose the `src` folder in the npm package.