### PR TITLE
Deprecate test data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner",
-    "version": "0.3.2",
+    "version": "0.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "displayName": "TAO Test Runner",
     "description": "TAO Test Runner API",
     "files": [

--- a/src/dataHolder.js
+++ b/src/dataHolder.js
@@ -30,7 +30,7 @@
 /**
  * @type {String[]} the list of default objects to create
  */
-var defaultObjects = ['testContext', 'testMap'];
+const defaultObjects = ['testContext', 'testMap'];
 
 /**
  * Creates a new data holder,

--- a/src/dataHolder.js
+++ b/src/dataHolder.js
@@ -30,7 +30,7 @@
 /**
  * @type {String[]} the list of default objects to create
  */
-var defaultObjects = ['testData', 'testContext', 'testMap'];
+var defaultObjects = ['testContext', 'testMap'];
 
 /**
  * Creates a new data holder,

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -424,6 +424,8 @@ function proxyFactory(proxyName, config) {
 
         /**
          * Gets the test definition data
+         * @deprecated
+         *
          * @returns {Promise} - Returns a promise. The test definition data will be provided on resolve.
          *                      Any error will be provided if rejected.
          * @fires getTestData

--- a/src/runner.js
+++ b/src/runner.js
@@ -604,6 +604,7 @@ function testRunnerFactory(providerName, pluginFactories, config) {
 
         /**
          * Get the test data/definition
+         * @deprecated
          * @returns {Object} the test data
          */
         getTestData: function getTestData() {
@@ -612,6 +613,7 @@ function testRunnerFactory(providerName, pluginFactories, config) {
 
         /**
          * Set the test data/definition
+         * @deprecated
          * @param {Object} testData - the test data
          * @returns {runner} chains
          */

--- a/src/runner.js
+++ b/src/runner.js
@@ -32,7 +32,7 @@ import dataHolderFactory from 'taoTests/runner/dataHolder';
  * @param {Function[]} pluginFactories
  * @param {Object} config
  * @param {String} config.serviceCallId - the identifier of the test session
- * @param {String} config.testDefition - the identifier of the test
+ * @param {String} config.testDefinition - the identifier of the test
  * @param {String} config.testCompilation - the identifier of the compiled test
  * @param {Object} config.provider - the seleted provider by type (ie. proxy, communicator, etc.)
  * @param {Object} config.options - the test runner configuration options
@@ -459,10 +459,12 @@ function testRunnerFactory(providerName, pluginFactories, config) {
         getPluginConfig(pluginName) {
             if ( pluginName && plugins[pluginName] ) {
                 const pluginsConfig = this.getPluginsConfig();
-                return pluginsConfig && pluginsConfig[pluginName];
+zsh:1: command not found: q
+                    return pluginsConfig[pluginName];
+                }
             }
 
-            return false;
+            return {};
         },
 
         /**

--- a/src/runner.js
+++ b/src/runner.js
@@ -458,8 +458,8 @@ function testRunnerFactory(providerName, pluginFactories, config) {
          */
         getPluginConfig(pluginName) {
             if ( pluginName && plugins[pluginName] ) {
-                const pluginsConfig = this.getPluginsConfig();
-zsh:1: command not found: q
+                const pluginsConfig = this.getPluginsConfig();i
+                if (pluginsConfig[pluginName]) {
                     return pluginsConfig[pluginName];
                 }
             }

--- a/src/runner.js
+++ b/src/runner.js
@@ -402,7 +402,7 @@ function testRunnerFactory(providerName, pluginFactories, config) {
          * @returns {Object} the config
          */
         getConfig() {
-            return config;
+            return config || {};
         },
 
         /**
@@ -415,7 +415,7 @@ function testRunnerFactory(providerName, pluginFactories, config) {
          * @returns {Object} the configuration options
          */
         getOptions() {
-            return config && config.options;
+            return this.getConfig().options || {};
         },
 
         /**
@@ -445,7 +445,7 @@ function testRunnerFactory(providerName, pluginFactories, config) {
          * @returns {Object} the configuration options
          */
         getPluginsConfig() {
-            return config && config.options && config.options.plugins;
+            return this.getOptions().plugins || {};
         },
 
         /**

--- a/src/runner.js
+++ b/src/runner.js
@@ -31,9 +31,14 @@ import dataHolderFactory from 'taoTests/runner/dataHolder';
  * @param {String} providerName
  * @param {Function[]} pluginFactories
  * @param {Object} config
- * @param {String|DOMElement|JQuery} config.contentContainer - the dom element that is going to holds the test content (item, rubick, etc)
- * @param {Array} [config.plugins] - the list of plugin instances to be initialized and bound to the test runner
- * @returns {runner|_L28.testRunnerFactory.runner}
+ * @param {String} config.serviceCallId - the identifier of the test session
+ * @param {String} config.testDefition - the identifier of the test
+ * @param {String} config.testCompilation - the identifier of the compiled test
+ * @param {Object} config.provider - the seleted provider by type (ie. proxy, communicator, etc.)
+ * @param {Object} config.options - the test runner configuration options
+ * @param {Object} config.options.plugins - the plugins configuration
+ * @param {jQueryElement} config.renderTo - the dom element that is going to holds the test content (item, rubick, etc)
+ * @returns {runner}
  */
 function testRunnerFactory(providerName, pluginFactories, config) {
     /**
@@ -393,10 +398,31 @@ function testRunnerFactory(providerName, pluginFactories, config) {
         },
 
         /**
+         * Get the whole test runner configuration
+         * @returns {Object} the config
+         */
+        getConfig() {
+            return config;
+        },
+
+        /**
+         * Get the options from the configuration parameters, (feature flags, parameter values, etc.)
+         *
+         * Alias to getConfig().options
+         *
+         * In deprecated mode, this is initialized through getTestData (after /init)
+         *
+         * @returns {Object} the configuration options
+         */
+        getOptions() {
+            return config && config.options;
+        },
+
+        /**
          * Get the runner pugins
          * @returns {plugin[]} the plugins
          */
-        getPlugins: function getPlugins() {
+        getPlugins() {
             return plugins;
         },
 
@@ -405,16 +431,38 @@ function testRunnerFactory(providerName, pluginFactories, config) {
          * @param {String} name - the plugin name
          * @returns {plugin} the plugin
          */
-        getPlugin: function getPlugin(name) {
+        getPlugin(name) {
             return plugins[name];
         },
 
         /**
-         * Get the config
-         * @returns {Object} the config
+         * Get the configuration of the plugins
+         *
+         * Alias to getConfig().options.plugins
+         *
+         * In deprecated mode, this is initialized through getTestData (after /init)
+         *
+         * @returns {Object} the configuration options
          */
-        getConfig: function getConfig() {
-            return config;
+        getPluginsConfig() {
+            return config && config.options && config.options.plugins;
+        },
+
+        /**
+         * Get the configuration of a given plugin
+         *
+         * In deprecated mode, this is initialized through getTestData (after /init)
+         *
+         * @param {String} pluginName - the name of the plugin
+         * @returns {Object} the configuration options of the plugin
+         */
+        getPluginConfig(pluginName) {
+            if ( pluginName && plugins[pluginName] ) {
+                const pluginsConfig = this.getPluginsConfig();
+                return pluginsConfig && pluginsConfig[pluginName];
+            }
+
+            return false;
         },
 
         /**

--- a/test/dataHolder/test.js
+++ b/test/dataHolder/test.js
@@ -50,7 +50,7 @@ define(['taoTests/runner/dataHolder'], function(dataHolderFactory) {
         holder = dataHolderFactory();
 
         assert.equal(typeof holder.get('testFoo'), 'undefined', 'testFoo is not a default');
-        assert.equal(typeof holder.get('testData'), 'object', 'testData is a default');
+        assert.equal(typeof holder.get('testData'), 'undefined', 'testData is a NOT default');
         assert.equal(typeof holder.get('testContext'), 'object', 'testContext is a default');
         assert.equal(typeof holder.get('testMap'), 'object', 'testMap is a default');
     });

--- a/test/runner/test.js
+++ b/test/runner/test.js
@@ -1000,7 +1000,7 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
 
                 assert.deepEqual(this.getPluginsConfig(), config.options.plugins, 'The plugins config is set');
 
-                assert.notOk(this.getPluginConfig('yup'), 'No plugin, no config');
+                assert.deepEqual(this.getPluginConfig('yup'), {},  'No plugin, no config');
 
                 assert.deepEqual(this.getPluginConfig('boo'), config.options.plugins.boo, 'The plugin config is set');
 

--- a/test/runner/test.js
+++ b/test/runner/test.js
@@ -69,59 +69,62 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
 
     QUnit.cases
         .init([
-            { name: 'init', title: 'init' },
-            { name: 'render', title: 'render' },
-            { name: 'finish', title: 'finish' },
-            { name: 'flush', title: 'flush' },
-            { name: 'destroy', title: 'destroy' },
-            { name: 'loadItem', title: 'loadItem' },
-            { name: 'renderItem', title: 'renderItem' },
-            { name: 'unloadItem', title: 'unloadItem' },
-            { name: 'disableItem', title: 'disableItem' },
-            { name: 'enableItem', title: 'enableItem' },
+            { title: 'init' },
+            { title: 'render' },
+            { title: 'finish' },
+            { title: 'flush' },
+            { title: 'destroy' },
+            { title: 'loadItem' },
+            { title: 'renderItem' },
+            { title: 'unloadItem' },
+            { title: 'disableItem' },
+            { title: 'enableItem' },
 
-            { name: 'getPlugins', title: 'getPlugins' },
-            { name: 'getPlugin', title: 'getPlugin' },
-            { name: 'getConfig', title: 'getConfig' },
-            { name: 'getState', title: 'getState' },
-            { name: 'setState', title: 'setState' },
-            { name: 'getItemState', title: 'getItemState' },
-            { name: 'setItemState', title: 'setItemState' },
-            { name: 'getTestData', title: 'getTestData' },
-            { name: 'getTestContext', title: 'getTestContext' },
-            { name: 'getTestMap', title: 'getTestMap' },
-            { name: 'getAreaBroker', title: 'getAreaBroker' },
-            { name: 'getProxy', title: 'getProxy' },
-            { name: 'getProbeOverseer', title: 'getProbeOverseer' },
-            { name: 'getDataHolder', title: 'getDataHolder' },
+            { title: 'getConfig' },
+            { title: 'getOptions' },
+            { title: 'getPlugins' },
+            { title: 'getPlugin' },
+            { title: 'getPluginsConfig' },
+            { title: 'getPluginConfig' },
+            { title: 'getState' },
+            { title: 'setState' },
+            { title: 'getItemState' },
+            { title: 'setItemState' },
+            { title: 'getTestData' },
+            { title: 'getTestContext' },
+            { title: 'getTestMap' },
+            { title: 'getAreaBroker' },
+            { title: 'getProxy' },
+            { title: 'getProbeOverseer' },
+            { title: 'getDataHolder' },
 
-            { name: 'next', title: 'next' },
-            { name: 'previous', title: 'previous' },
-            { name: 'jump', title: 'jump' },
-            { name: 'skip', title: 'skip' },
-            { name: 'exit', title: 'exit' },
-            { name: 'pause', title: 'pause' },
-            { name: 'resume', title: 'resume' },
-            { name: 'timeout', title: 'timeout' },
+            { title: 'next' },
+            { title: 'previous' },
+            { title: 'jump' },
+            { title: 'skip' },
+            { title: 'exit' },
+            { title: 'pause' },
+            { title: 'resume' },
+            { title: 'timeout' },
 
-            { name: 'trigger', title: 'trigger' },
-            { name: 'before', title: 'before' },
-            { name: 'on', title: 'on' },
-            { name: 'after', title: 'after' }
+            { title: 'trigger' },
+            { title: 'before' },
+            { title: 'on' },
+            { title: 'after' }
         ])
         .test('api', function(data, assert) {
             var runner;
             runnerFactory.registerProvider('mock', mockProvider);
             runner = runnerFactory();
             assert.equal(
-                typeof runner[data.name],
+                typeof runner[data.title],
                 'function',
                 `The runner instance exposes a "${data.title}" function`
             );
         });
 
     QUnit.module('provider', {
-        afterEach: function() {
+        afterEach() {
             runnerFactory.clearProviders();
         }
     });
@@ -145,18 +148,45 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
         runner.init();
     });
 
-    QUnit.test('get config', function(assert) {
-        var ready = assert.async();
-        var config = {
-            moo: 'norz'
+    QUnit.test('get configurations', assert => {
+        const ready = assert.async();
+        const config = {
+            serviceCallId : '123-456-789',
+            provider : {
+                proxy : 'foo',
+                communicator: 'bar'
+            },
+            bootstrap : {
+                serviceUrl : '/foo'
+            },
+            options : {
+                exitUrl : '/bye',
+                fullScreen : false,
+                progress : 'percent',
+                plugins : {
+                    title :  {
+                        section : true
+                    },
+                    connectivity : {
+                        icon : 'net'
+                    }
+                }
+            }
         };
-        assert.expect(1);
+        assert.expect(3);
 
         runnerFactory.registerProvider('foo', {
             loadAreaBroker: _.noop,
-            init: function() {
-                var myConfig = this.getConfig();
-                assert.deepEqual(myConfig, config, 'The retrieved config is the right one');
+            init() {
+                const testRunnerConfig = this.getConfig();
+                assert.deepEqual(testRunnerConfig, config, 'The retrieved config match');
+
+                const testRunnerOptions = this.getOptions();
+                assert.deepEqual(testRunnerOptions, config.options, 'The retrieved options match');
+
+                const pluginsConfig = this.getPluginsConfig();
+                assert.deepEqual(pluginsConfig, config.options.plugins, 'The retrieved plugins config match');
+
                 ready();
             }
         });
@@ -871,7 +901,7 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
     QUnit.test('getDataHolder', function(assert) {
         var dataHolder;
 
-        assert.expect(6);
+        assert.expect(5);
 
         runnerFactory.registerProvider('foo', mockProvider);
 
@@ -880,13 +910,12 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
         assert.equal(typeof dataHolder, 'object', 'The runner exposes the data holder');
         assert.equal(typeof dataHolder.get, 'function', 'The data holder has the get method');
         assert.equal(typeof dataHolder.set, 'function', 'The data holder has the set method');
-        assert.equal(typeof dataHolder.get('testData'), 'object', 'The data holder holds the correct data');
         assert.equal(typeof dataHolder.get('testContext'), 'object', 'The data holder holds the correct data');
         assert.equal(typeof dataHolder.get('testMap'), 'object', 'The data holder holds the correct data');
     });
 
     QUnit.module('plugins', {
-        beforeEach: function() {
+        beforeEach() {
             runnerFactory.clearProviders();
         }
     });
@@ -923,6 +952,64 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
                 assert.equal(typeof this.getPlugin('boo'), 'object', 'The boo plugin exists');
             })
             .init();
+    });
+
+
+    QUnit.test('get plugin config', assert => {
+        const ready = assert.async();
+        const config = {
+            serviceCallId : '123-456-789',
+            provider : {
+                proxy : 'foo'
+            },
+            bootstrap : {
+                serviceUrl : '/foo'
+            },
+            options : {
+                fullScreen : false,
+                plugins : {
+                    boo :  {
+                        section : true,
+                        testPart : false
+                    },
+                    bar : {
+                        icon : 'net',
+                        timeout : 3500
+                    }
+                }
+            }
+        };
+
+        const boo = pluginFactory({
+            name: 'boo',
+            init() {}
+        });
+        const bar = pluginFactory({
+            name: 'bar',
+            init() {}
+        });
+
+        assert.expect(7);
+
+        runnerFactory.registerProvider('foo', {
+            loadAreaBroker: _.noop,
+            init() {
+                assert.equal(typeof this.getPlugin('moo'), 'undefined', 'The moo plugin does not exist');
+                assert.equal(typeof this.getPlugin('boo'), 'object', 'The boo plugin exists');
+                assert.equal(typeof this.getPlugin('bar'), 'object', 'The bar plugin exists');
+
+                assert.deepEqual(this.getPluginsConfig(), config.options.plugins, 'The plugins config is set');
+
+                assert.notOk(this.getPluginConfig('yup'), 'No plugin, no config');
+
+                assert.deepEqual(this.getPluginConfig('boo'), config.options.plugins.boo, 'The plugin config is set');
+
+                assert.deepEqual(this.getPluginConfig('bar'), config.options.plugins.bar, 'The plugin config is set');
+                ready();
+            }
+        });
+
+        runnerFactory('foo', { boo, bar }, config).init();
     });
 
     QUnit.test('persistent state', function(assert) {


### PR DESCRIPTION
 Related to https://oat-sa.atlassian.net/browse/NEX-238

 - Deprecate `testData` (but keep it to ensure backward compatibility)
 - Add new methods for the test runner API : 
   - `getConfig` returns the full test runner configuration
   - `getOptions` returns the configuration options (feature flags, platform/tenant config). Previously returned by `testData.config` and today under `config.options`
 - `getPluginsConfig` returns the plugins configuration. Previously returned by `testData.config.plugins` and today under `config.options.plugins
 - `getPluginConfig` the configuration of a given plugin (same as `this.getConfig` within a plugin)

How to test : 
 - Those changes are covered by unit tests : `npm run test`
 - Try launching the test runner

Todo : 
 - [x] release to npm