### PR TITLE
[WIP] fix/TAO-9561 not trigger error in offline mode

### DIFF
--- a/src/proxy.js
+++ b/src/proxy.js
@@ -342,7 +342,9 @@ function proxyFactory(proxyName, config) {
                                     }
                                 })
                                 .on('error', function(err) {
-                                    self.trigger('error', err);
+                                    if (this.isOnline()()) {
+                                        self.trigger('error', err);
+                                    }
                                 })
                                 .on('receive', function(response) {
                                     self.setOnline();


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-9561

If an error in offline mode doesn't trigger an error. It will be handled in `src/proxy/offline/proxy.js`

Related to: https://github.com/oat-sa/tao-test-runner-qti-fe/pull/71