### PR TITLE
Feature/nex 1030/extend skip arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oat-sa/tao-test-runner",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "displayName": "TAO Test Runner",
     "description": "TAO Test Runner API",
     "files": [

--- a/src/runner.js
+++ b/src/runner.js
@@ -749,18 +749,18 @@ function testRunnerFactory(providerName, pluginFactories = [], config = {}) {
         /**
          * Skip alias
          * @param {String|*} [scope] - the movement scope
-         * @param {Number|*} [ref] - the item ref
          * @param {String|*} [direction] - next/previous/jump
-         * @fires runner#move
+         * @param {Number|*} [ref] - the item ref
+         * @fires runner#skip
          * @returns {runner} chains
          */
-        skip(scope, ref, direction) {
+        skip(scope, direction, ref) {
             if (_.isFunction(provider.skip)) {
-                return providerRun('skip', scope, ref, direction);
+                return providerRun('skip', scope, direction, ref);
             }
 
             //backward compat
-            this.trigger('skip', scope, ref, direction);
+            this.trigger('skip', scope, direction, ref);
             return this;
         },
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -749,16 +749,19 @@ function testRunnerFactory(providerName, pluginFactories = [], config = {}) {
         /**
          * Skip alias
          * @param {String|*} [scope] - the movement scope
+         * @param {Number|*} [ref] - the item ref
+         * @param {String|*} [direction] - next/previous/jump
          * @fires runner#move
          * @returns {runner} chains
          */
-        skip(scope) {
+        skip(scope, ref, direction) {
+            console.log('skiip');
             if (_.isFunction(provider.skip)) {
-                return providerRun('skip', scope);
+                return providerRun('skip', scope, ref, direction);
             }
 
             //backward compat
-            this.trigger('skip', scope);
+            this.trigger('skip', scope, ref, direction);
             return this;
         },
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -755,7 +755,6 @@ function testRunnerFactory(providerName, pluginFactories = [], config = {}) {
          * @returns {runner} chains
          */
         skip(scope, ref, direction) {
-            console.log('skiip');
             if (_.isFunction(provider.skip)) {
                 return providerRun('skip', scope, ref, direction);
             }

--- a/test/runner/test.js
+++ b/test/runner/test.js
@@ -720,7 +720,6 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
                 assert.ok(false, 'Skip is not a move');
             })
             .on('skip', function(scope, ref, direction) {
-                console.log(scope, ref, direction)
                 assert.equal(scope, 'section', 'The scope is correct');
                 assert.equal(ref, 1, 'The ref is correct');
                 assert.equal(direction, 'jump', 'The direction is correct');

--- a/test/runner/test.js
+++ b/test/runner/test.js
@@ -707,20 +707,23 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
 
     QUnit.test('skip', function(assert) {
         var ready = assert.async();
-        assert.expect(2);
+        assert.expect(4);
 
         runnerFactory.registerProvider('mock', mockProvider);
 
         runnerFactory('mock')
             .on('ready', function() {
                 assert.ok(true, 'The runner is ready');
-                this.skip('section');
+                this.skip('section', 1, 'jump');
             })
             .on('move', function() {
                 assert.ok(false, 'Skip is not a move');
             })
-            .on('skip', function(scope) {
+            .on('skip', function(scope, ref, direction) {
+                console.log(scope, ref, direction)
                 assert.equal(scope, 'section', 'The scope is correct');
+                assert.equal(ref, 1, 'The ref is correct');
+                assert.equal(direction, 'jump', 'The direction is correct');
                 ready();
             })
             .init();
@@ -937,7 +940,7 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
         { title: 'next', parameters: ['item'] },
         { title: 'previous', parameters: ['section'] },
         { title: 'jump', parameters: [10, 'item'] },
-        { title: 'skip', parameters: ['item'] },
+        { title: 'skip', parameters: ['item', null, 'next'] },
         { title: 'exit', parameters: ['logout'] },
         { title: 'pause', parameters: [] },
         { title: 'resume', parameters: [] , pause : true },

--- a/test/runner/test.js
+++ b/test/runner/test.js
@@ -714,15 +714,15 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
         runnerFactory('mock')
             .on('ready', function() {
                 assert.ok(true, 'The runner is ready');
-                this.skip('section', 1, 'jump');
+                this.skip('section', 'jump', 1);
             })
             .on('move', function() {
                 assert.ok(false, 'Skip is not a move');
             })
-            .on('skip', function(scope, ref, direction) {
+            .on('skip', function(scope, direction, ref) {
                 assert.equal(scope, 'section', 'The scope is correct');
-                assert.equal(ref, 1, 'The ref is correct');
                 assert.equal(direction, 'jump', 'The direction is correct');
+                assert.equal(ref, 1, 'The ref is correct');
                 ready();
             })
             .init();
@@ -939,7 +939,7 @@ define(['lodash', 'core/eventifier', 'taoTests/runner/runner', 'taoTests/runner/
         { title: 'next', parameters: ['item'] },
         { title: 'previous', parameters: ['section'] },
         { title: 'jump', parameters: [10, 'item'] },
-        { title: 'skip', parameters: ['item', null, 'next'] },
+        { title: 'skip', parameters: ['item', 'next', null] },
         { title: 'exit', parameters: ['logout'] },
         { title: 'pause', parameters: [] },
         { title: 'resume', parameters: [] , pause : true },


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/NEX-1030

In the NG test runner we want the possibility to skip an item without submitting a response - but not just to the next `scope` (item|section|part), but also to the previous, or to any reachable item (via the Overview screen).

This PR adds arguments to `skip(scope)`, making it `skip(scope, ref, direction)`.

It could be called as
```
testRunner.skip('item', null, 'previous')
testRunner.skip('section', null, 'next')
testRunner.skip('item', 17, 'jump')
```
and the provider should handle the mapping of the delegated call to the appropriate type of action.