### PR TITLE
Fix TR-3287 remove source based npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4198,9 +4198,10 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
-        "eve": {
-            "version": "git://github.com/adobe-webplatform/eve.git#eef80ed8d188423c2272746fb8ae5cc8dad84cb1",
-            "from": "git://github.com/adobe-webplatform/eve.git#eef80ed",
+        "eve-raphael": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
+            "integrity": "sha1-F8dUt5K+7z+maE15z1pHxjxM2jA=",
             "dev": true
         },
         "extract-zip": {
@@ -6238,12 +6239,12 @@
             "dev": true
         },
         "raphael": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.2.0.tgz",
-            "integrity": "sha1-qdhPJj7I/obS4WzCz36pq8IA1ho=",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
+            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
             "dev": true,
             "requires": {
-                "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+                "eve-raphael": "0.5.0"
             }
         },
         "raw-body": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "popper.js": "1.15.0",
         "prettier": "^2.4.1",
         "qunit": "^2.17.2",
-        "raphael": "2.2.0",
+        "raphael": "^2.3.0",
         "require-css": "^0.1.10",
         "requirejs-plugins": "^1.0.2",
         "rollup": "^1.32.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "popper.js": "1.15.0",
         "prettier": "^2.4.1",
         "qunit": "^2.17.2",
-        "raphael": "^2.3.0",
+        "raphael": "2.3.0",
         "require-css": "^0.1.10",
         "requirejs-plugins": "^1.0.2",
         "rollup": "^1.32.1",


### PR DESCRIPTION
# [TR-3287](https://oat-sa.atlassian.net/browse/TR-3287)

- fix: remove source-based npm dependencies by updating `raphael` package dependency to `2.3.0`