### PR TITLE
Feature/tr 3264/add runnerComponent copy without handlebars

### DIFF
--- a/src/runnerComponentSimple.js
+++ b/src/runnerComponentSimple.js
@@ -1,0 +1,239 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA ;
+ */
+
+/**
+ * A component that loads and instantiate a test runner inside an element:
+ * A light-weight version of `runnerComponent.js`:
+ * - removes `handlebars` template dependency
+ * - removes `ui/component` dependency, so it's api is not inherited
+ * Logic stays the same:
+ * - provider initialization
+ * - configuration validation
+ * Use it instead of `runnerComponent.js` in projects which do not use `handlebars`
+ */
+
+import _ from 'lodash';
+import eventifier from 'core/eventifier';
+import runnerFactory from 'taoTests/runner/runner';
+import providerLoader from 'taoTests/runner/providerLoader';
+
+/**
+ * Validate required options from the configuration
+ * @param {Object} config
+ * @returns {Boolean} true if valid
+ * @throws {TypeError} in case of validation failure
+ */
+function validateTestRunnerConfiguration(config = {}) {
+    const requiredProperties = ['providers', 'options', 'serviceCallId'];
+    if (typeof config !== 'object') {
+        throw new TypeError(`The runner configuration must be an object, '${typeof config}' received`);
+    }
+    if (requiredProperties.some(property => typeof config[property] === 'undefined')) {
+        throw new TypeError(
+            `The runner configuration must contains at least the following properties : ${requiredProperties.join(',')}`
+        );
+    }
+    return true;
+}
+
+/**
+ * Get the selected provider if set or infer it from the providers list
+ * @param {String} type - the type of provider (runner, communicator, proxy, etc.)
+ * @param {Object} config
+ * @returns {String} the selected provider for the given type
+ */
+function getSelectedProvider(type = 'runner', config = {}) {
+    if (config.provider && config.provider[type]) {
+        return config.provider[type];
+    }
+
+    if (config.providers && config.providers[type]) {
+        const typeProviders = config.providers[type];
+        if (typeof typeProviders === 'object' && (typeProviders.id || typeProviders.name)) {
+            return typeProviders.id || typeProviders.name;
+        }
+        if (Array.isArray(typeProviders) && typeProviders.length > 0) {
+            return typeProviders[0].id || typeProviders[0].name;
+        }
+    }
+    return false;
+}
+
+/**
+ * Wraps a test runner into a component
+ * @param {jQuery|HTMLElement|String} container - The container in which renders the component
+ * @param {Object} config - The component configuration options
+ * @param {String} config.serviceCallId - The identifier of the test session
+ * @param {Object} config.providers
+ * @param {Object} config.options
+ * @param {Boolean} [config.loadFromBundle=false] - do we load the modules from the bundles
+ * @param {Boolean} [config.replace] - When the component is appended to its container, clears the place before
+ * @param {Number|String} [config.width] - The width in pixels, or 'auto' to use the container's width
+ * @param {Number|String} [config.height] - The height in pixels, or 'auto' to use the container's height
+ * @returns {runnerComponent}
+ */
+export default function runnerComponentFactory(container = null, config = {}) {
+    let runner = null;
+    let plugins = [];
+
+    if (!container) {
+        throw new TypeError('A container element must be defined to contain the runnerComponent');
+    }
+
+    validateTestRunnerConfiguration(config);
+
+    const runnerComponentApi = {
+        /**
+         * Initializes the component
+         * @param {Object} configuration
+         * @returns {runner}
+         * @fires runner#init
+         */
+        init: function init(configuration) {
+            this.config = _(configuration || {})
+                .omit(function (value) {
+                    return value === null || typeof value === 'undefined';
+                })
+                .value();
+
+            this.trigger('init');
+            return this;
+        },
+
+        /**
+         * Uninstalls the component
+         * @returns {runner}
+         * @fires component#destroy
+         */
+        destroy: function destroy() {
+            this.trigger('destroy');
+            return this;
+        },
+
+        /**
+         * Renders the component
+         * @returns {runner}
+         * @fires runner#render
+         */
+        render: function render() {
+            this.trigger('render');
+            return this;
+        },
+
+        /**
+         * Shows the component
+         * @returns {runner}
+         * @fires runner#show
+         */
+        show: function show() {
+            this.trigger('show', this);
+            return this;
+        },
+
+        /**
+         * Hides the component
+         * @returns {runner}
+         * @fires runner#hide
+         */
+        hide: function hide() {
+            this.trigger('hide', this);
+            return this;
+        },
+
+        /**
+         * Get the component's configuration
+         * @returns {Object}
+         */
+        getConfig: function getConfig() {
+            return this.config || {};
+        },
+
+        /**
+         * Gets the test runner
+         * @returns {runner}
+         */
+        getRunner() {
+            return runner;
+        }
+    };
+    const runnerComponent = eventifier(runnerComponentApi);
+
+    runnerComponent
+        .on('init', function () {
+            //load the defined providers for the runner, the proxy, the communicator, the plugins, etc.
+            return providerLoader(config.providers, config.loadFromBundle)
+                .then(results => {
+                    if (results && results.plugins) {
+                        plugins = results.plugins;
+                    }
+
+                    this.render(container);
+                    this.hide();
+                })
+                .catch(err => this.trigger('error', err));
+        })
+        .on('render', function () {
+            this.component = document.createElement('div');
+            this.component.classList.add('runner-component');
+            container.append(this.component);
+
+            const runnerConfig = Object.assign(_.omit(this.config, ['providers']), {
+                renderTo: this.component
+            });
+            runnerConfig.provider = Object.keys(this.config.providers).reduce((acc, providerType) => {
+                if (!acc[providerType] && providerType !== 'plugins') {
+                    acc[providerType] = getSelectedProvider(providerType, this.config);
+                }
+                return acc;
+            }, runnerConfig.provider || {});
+
+            runner = runnerFactory(runnerConfig.provider.runner, plugins, runnerConfig)
+                .on('ready', () => {
+                    _.defer(() => {
+                        this.trigger('ready', runner).show();
+                    });
+                })
+                .on('destroy', () => (runner = null))
+                .spread(this, 'error')
+                .init();
+        })
+        .on('hide', function () {
+            if (this.component) {
+                this.component.classList.add('hidden');
+            }
+        })
+        .on('show', function () {
+            if (this.component) {
+                this.component.classList.remove('hidden');
+            }
+        })
+        .on('destroy', function () {
+            var destroying = runner && runner.destroy();
+            runner = null;
+
+            if (this.component) {
+                this.component.remove();
+            }
+            return destroying;
+        })
+        .after('destroy', function () {
+            this.removeAllListeners();
+        });
+
+    return runnerComponent.init(config);
+}

--- a/test/runnerComponentSimple/test.html
+++ b/test/runnerComponentSimple/test.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Test Runner - Runner Component (Simple)</title>
+        <script type="text/javascript" src="/environment/require.js"></script>
+        <script type="text/javascript">
+            require(['/environment/config.js'], function () {
+                require(['qunitEnv'], function () {
+                    define('taoItems/runner/api/itemRunner', [], function () {
+                        return {
+                            register() {}
+                        };
+                    });
+                    require(['taoTests/test/runner/runnerComponentSimple/test'], function () {
+                        // QUnit.config.notrycatch = true;
+                        QUnit.config.reorder = false;
+                        QUnit.start();
+                    });
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture">
+            <div id="fixture-module"></div>
+            <div id="fixture-config"></div>
+            <div id="fixture-method"></div>
+            <div id="fixture-init"></div>
+            <div id="fixture-providers"></div>
+            <div id="fixture-plugins"></div>
+            <div id="fixture-error"></div>
+            <div id="fixture-get"></div>
+        </div>
+        <div id="playground"></div>
+    </body>
+</html>

--- a/test/runnerComponentSimple/test.js
+++ b/test/runnerComponentSimple/test.js
@@ -1,0 +1,299 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017-2023 (original work) Open Assessment Technologies SA ;
+ */
+define([
+    'taoTests/runner/runnerComponentSimple',
+    'taoTests/runner/runner',
+    'json!taoTests/test/runner/mocks/config.json'
+], function (runnerComponent, runner, sampleConfig) {
+    'use strict';
+
+    QUnit.module('factory');
+
+    QUnit.test('module', assert => {
+        const container = document.getElementById('fixture-module');
+
+        assert.expect(3);
+
+        assert.equal(typeof runnerComponent, 'function', 'The runnerComponent module exposes a function');
+        assert.equal(
+            typeof runnerComponent(container, sampleConfig),
+            'object',
+            'The runnerComponent factory produces an object'
+        );
+
+        assert.notStrictEqual(
+            runnerComponent(container, sampleConfig),
+            runnerComponent(container, sampleConfig),
+            'The runnerComponent factory provides a different object on each call'
+        );
+    });
+
+    QUnit.cases
+        .init([
+            { title: 'init' },
+            { title: 'destroy' },
+            { title: 'show' },
+            { title: 'hide' },
+            { title: 'getConfig' },
+            { title: 'getRunner' },
+            { title: 'on' },
+            { title: 'before' },
+            { title: 'after' },
+            { title: 'trigger' }
+        ])
+        .test('API ', (data, assert) => {
+            const container = document.getElementById('fixture-module');
+
+            assert.expect(1);
+
+            assert.equal(
+                typeof runnerComponent(container, sampleConfig)[data.title],
+                'function',
+                `The runnerComponent instance exposes a "${data.title}" function`
+            );
+        });
+
+    QUnit.module('Component configuration', {
+        beforeEach() {
+            runner.clearProviders();
+        }
+    });
+
+    QUnit.test('Wrong configuration', assert => {
+        assert.expect(3);
+
+        const container = document.getElementById('fixture-module');
+
+        assert.throws(() => runnerComponent(), /A container element must be defined to contain the runnerComponent/);
+
+        assert.throws(() => runnerComponent(container), /the following properties : providers,options,serviceCallId/);
+
+        assert.throws(
+            () =>
+                runnerComponent(container, {
+                    serviceCallId: 'foo',
+                    options: {}
+                }),
+            /the following properties : providers,options,serviceCallId/
+        );
+    });
+
+    QUnit.module('Component lifecycle', {
+        beforeEach() {
+            runner.clearProviders();
+        }
+    });
+
+    QUnit.test('Initialize from a registered provider', assert => {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-init');
+        const config = {
+            serviceCallId: 'foo',
+            provider: {
+                runner: 'mock-init'
+            },
+            providers: {},
+            options: {}
+        };
+
+        assert.expect(8);
+
+        runner.registerProvider('mock-init', {
+            loadAreaBroker: () => {},
+            init: function () {
+                assert.ok(true, 'The init method has been called');
+            },
+            render: function () {
+                assert.ok(true, 'The render method has been called');
+            },
+            destroy: function () {
+                assert.ok(true, 'The destroy method has been called');
+
+                setTimeout(() => {
+                    assert.equal(container.childNodes.length, 0, 'The component has been destroyed');
+
+                    ready();
+                }, 200);
+            }
+        });
+
+        assert.equal(container.childNodes.length, 0, 'The runner is not rendered');
+
+        runnerComponent(container, config)
+            .on('error', err => assert.ok(false, err.message))
+            .on('ready', function () {
+                assert.ok(true, 'The runner is ready');
+                assert.equal(container.childNodes.length, 1, 'The runner is rendered');
+                assert.equal(container.querySelectorAll('.runner-component').length, 1, 'The html element is created');
+
+                this.destroy();
+            });
+    });
+
+    QUnit.test('Initialize from providers to load', assert => {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-init');
+
+        assert.expect(3);
+
+        assert.deepEqual(runner.getAvailableProviders(), [], 'No providers are registered');
+
+        runnerComponent(container, sampleConfig)
+            .on('error', err => assert.ok(false, err.message))
+            .on('render', function () {
+                assert.deepEqual(runner.getAvailableProviders(), ['mock-runner'], 'The correct provider is loaded');
+                this.getRunner().on('mock-runner-loaded', () => {
+                    assert.ok(true, 'The mock provider has triggered and event');
+
+                    this.destroy();
+                });
+            })
+            .on('destroy', ready);
+    });
+
+    QUnit.test('Get selected providers', assert => {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-init');
+
+        assert.expect(6);
+
+        const testConfig = Object.assign(sampleConfig, {
+            provider: {
+                communicator: 'request'
+            },
+            providers: {
+                runner: {
+                    id: 'mock-runner',
+                    module: 'taoTests/test/runner/mocks/mockRunnerProvider',
+                    category: 'runner'
+                },
+                itemRunner: {
+                    id: 'mock-item-runner',
+                    module: 'taoTests/test/runner/mocks/mockItemRunnerProvider',
+                    category: 'runner'
+                },
+                communicator: {
+                    id: 'request',
+                    module: 'core/communicator/request',
+                    category: 'request'
+                },
+                proxy: [
+                    {
+                        id: 'mock-proxy1',
+                        module: 'taoTests/test/runner/mocks/mockProxyProvider',
+                        category: 'proxy'
+                    },
+                    {
+                        id: 'mock-proxy2',
+                        module: 'taoTests/test/runner/mocks/mockProxyProvider',
+                        category: 'proxy'
+                    }
+                ],
+                plugins: [
+                    {
+                        id: 'fooglin',
+                        module: 'taoTests/test/runner/mocks/mockPlugin1',
+                        category: 'content'
+                    },
+                    {
+                        id: 'barglin',
+                        module: 'taoTests/test/runner/mocks/mockPlugin2',
+                        category: 'tools'
+                    }
+                ]
+            }
+        });
+
+        runnerComponent(container, testConfig)
+            .on('error', err => assert.ok(false, err.message))
+            .on('ready', function () {
+                const config = this.getRunner().getConfig();
+
+                assert.equal(typeof config.provider, 'object', 'The provider has been generated');
+                assert.equal(config.provider.proxy, 'mock-proxy1', 'The correct proxy provider is selected');
+                assert.equal(config.provider.runner, 'mock-runner', 'The correct runner provider is selected');
+                assert.equal(
+                    config.provider.itemRunner,
+                    'mock-item-runner',
+                    'The correct item runner provider is selected'
+                );
+                assert.equal(config.provider.communicator, 'request', 'The communicator provider is kept');
+                assert.equal(typeof config.provider.plugins, 'undefined', 'Plugins provider is kept');
+
+                this.destroy();
+            })
+            .on('destroy', ready);
+    });
+
+    QUnit.test('spread error event from test runner', function (assert) {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-error');
+        const error = 'oops!';
+
+        assert.expect(2);
+
+        runnerComponent(container, sampleConfig)
+            .on('error', function (err) {
+                assert.equal(err, error, 'The error has been forwarded');
+                ready();
+            })
+            .on('ready', function (testRunner) {
+                assert.equal(typeof testRunner, 'object', 'The runner instance is provided');
+
+                testRunner.trigger('error', error);
+            });
+    });
+
+    QUnit.test('spread error event from test runner', function (assert) {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-error');
+        const error = 'oops!';
+
+        assert.expect(2);
+
+        runnerComponent(container, sampleConfig)
+            .on('error', function (err) {
+                assert.equal(err, error, 'The error has been forwarded');
+                ready();
+            })
+            .on('ready', function (testRunner) {
+                assert.equal(typeof testRunner, 'object', 'The runner instance is provided');
+
+                testRunner.trigger('error', error);
+            });
+    });
+
+    QUnit.test('getRunner', function (assert) {
+        const ready = assert.async();
+        const container = document.getElementById('fixture-get');
+
+        assert.expect(3);
+
+        runnerComponent(container, sampleConfig)
+            .on('ready', function (testRunner) {
+                assert.equal(typeof testRunner, 'object', 'The runner instance is provided');
+
+                assert.equal(testRunner, this.getRunner(), 'The runner is reachable');
+                this.destroy();
+            })
+            .on('destroy', function () {
+                assert.equal(this.getRunner(), null, 'The runner has been destroyed');
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-3264

See https://github.com/oat-sa/tao-deliver-fe/pull/861 and https://github.com/oat-sa/pisa-deliver-fe/pull/56
(remove handlebars dependency from NextGen frontend apps)